### PR TITLE
Hook into textobj-function via `b:textobj_function_select`

### DIFF
--- a/after/ftplugin/python/textobj-python.vim
+++ b/after/ftplugin/python/textobj-python.vim
@@ -22,6 +22,19 @@
 "     SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 " }}}
 
+" Integration with https://github.com/kana/vim-textobj-function.
+if !exists('b:textobj_function_select')
+  let b:textobj_function_select = function('textobj#python#function_select')
+
+  if exists('b:undo_ftplugin')
+    let b:undo_ftplugin .= '|'
+  else
+    let b:undo_ftplugin = ''
+  endif
+  let b:undo_ftplugin .= 'unlet b:textobj_function_select'
+endif
+
+
 if exists('g:loaded_textobj_python')
   finish
 endif

--- a/autoload/textobj/python.vim
+++ b/autoload/textobj/python.vim
@@ -149,3 +149,7 @@ endfunction
 function! textobj#python#function_select_i()
     return textobj#python#select_i('def')
 endfunction
+
+function! textobj#python#function_select(object_type)
+  return textobj#python#function_select_{a:object_type}()
+endfunction


### PR DESCRIPTION
Fixes https://github.com/bps/vim-textobj-python/issues/4
