### PR TITLE
Fix "Don't cross scope for defn()"

### DIFF
--- a/autoload/textobj/python.vim
+++ b/autoload/textobj/python.vim
@@ -50,7 +50,7 @@ function! textobj#python#find_defn_line(kwd)
                     " Found a defn, make sure there aren't any statements at a
                     " shallower indent level in between
                     for l:l in range(l:defn_pos[1] + 1, l:cur_pos[1])
-                        if getline(l:l) !~# '^\s*$' && indent(l:l) < l:defn_indent
+                        if getline(l:l) !~# '^\s*$' && indent(l:l) <= l:defn_indent
                             throw "defn-not-found"
                         endif
                     endfor

--- a/test/textobj-python.vader
+++ b/test/textobj-python.vader
@@ -159,8 +159,8 @@ Execute (Old-style no ancestor class a class):
   AssertEqual 86, getpos("'<")[1]
   AssertEqual 91, getpos("'>")[1]
 
-# Execute (Don't cross scope for defn):
-#   call cursor(80, 1)
-#   normal vif<Esc>
-#   AssertEqual 80, getpos("'<")[1]
-#   AssertEqual 80, getpos("'<")[1]
+Execute (Don't cross scope for defn):
+  call cursor(80, 1)
+  normal vif<Esc>
+  AssertEqual 80, getpos("'<")[1]
+  AssertEqual 80, getpos("'<")[1]


### PR DESCRIPTION
Note: this is also included in #10.