### PR TITLE
Make `af` and `ac` select surrounding blank lines

### DIFF
--- a/autoload/textobj/python.vim
+++ b/autoload/textobj/python.vim
@@ -172,9 +172,30 @@ function! s:find_defn(kwd)
     return ['V', l:defn_pos, l:end_pos]
 endfunction
 
+function! s:select_surrounding_blank_lines(pos)
+    let l:defn_pos = copy(a:pos)
+
+    let l:blanks_on_start = l:defn_pos[1][1] - (prevnonblank(l:defn_pos[1][1] - 1) + 1)
+    let l:current_block_indent_level = indent(l:defn_pos[1][1])
+    let l:next_block_linenr = nextnonblank(l:defn_pos[2][1] + 1)
+    let l:next_block_indent_level = indent(l:next_block_linenr)
+
+    if l:next_block_linenr != 0
+        if l:current_block_indent_level != 0 && l:next_block_indent_level == 0
+            let l:desired_blanks = 2
+            let l:desired_blanks = max([0, l:desired_blanks - l:blanks_on_start])
+            let l:defn_pos[2][1] = l:next_block_linenr - 1 - l:desired_blanks
+        else
+            let l:defn_pos[2][1] = l:next_block_linenr - 1
+        endif
+    endif
+    return l:defn_pos
+endfunction
+
 function! textobj#python#select_a(kwd)
     let l:defn_pos = s:find_defn(a:kwd)
     if type(l:defn_pos) == type([])
+        let l:defn_pos = s:select_surrounding_blank_lines(l:defn_pos)
         let l:defn_pos[1][1] = textobj#python#find_prev_decorators(l:defn_pos[1][1])
         return l:defn_pos
     endif

--- a/autoload/textobj/python.vim
+++ b/autoload/textobj/python.vim
@@ -197,8 +197,8 @@ endfunction
 function! textobj#python#select_a(kwd)
     let l:defn_pos = s:find_defn(a:kwd)
     if type(l:defn_pos) == type([])
-        let l:defn_pos = s:select_surrounding_blank_lines(l:defn_pos)
         let l:defn_pos[1][1] = textobj#python#find_prev_decorators(l:defn_pos[1][1])
+        let l:defn_pos = s:select_surrounding_blank_lines(l:defn_pos)
         return l:defn_pos
     endif
     return 0

--- a/autoload/textobj/python.vim
+++ b/autoload/textobj/python.vim
@@ -188,6 +188,8 @@ function! s:select_surrounding_blank_lines(pos)
         else
             let l:defn_pos[2][1] = l:next_block_linenr - 1
         endif
+    else
+        let l:defn_pos[1][1] = prevnonblank(l:defn_pos[1][1] - 1) + 1
     endif
     return l:defn_pos
 endfunction

--- a/test/test.py
+++ b/test/test.py
@@ -154,3 +154,7 @@ def function_with_multiline_decorators():
 class ClassWithMultilineDecorators:
     # ClassWithMultilineDecorators
     pass
+
+
+def at_end_of_file():
+    pass

--- a/test/test.py
+++ b/test/test.py
@@ -156,5 +156,14 @@ class ClassWithMultilineDecorators:
     pass
 
 
+class RegularClass():
+    def foo(self):
+        pass
+
+    @decorator
+    def method_with_decorator(self):
+        pass
+
+
 def at_end_of_file():
     pass

--- a/test/textobj-python.vader
+++ b/test/textobj-python.vader
@@ -129,7 +129,7 @@ Execute (Nested classes inner inner class):
   AssertEqual 58, getpos("'<")[1]
   AssertEqual 58, getpos("'>")[1]
 
-Execute (FIXME Nested classes inner a class):
+Execute (Nested classes inner a class):
   call cursor(57, 1)
   normal vac<cr>
   AssertEqual 57, getpos("'<")[1]
@@ -141,7 +141,7 @@ Execute (Class nested in function inner class):
   AssertEqual 66, getpos("'<")[1]
   AssertEqual 70, getpos("'>")[1]
 
-Execute (FIXME Class nested in function a class):
+Execute (Class nested in function a class):
   call cursor(65, 1)
   normal vac<cr>
   AssertEqual 65, getpos("'<")[1]

--- a/test/textobj-python.vader
+++ b/test/textobj-python.vader
@@ -13,7 +13,7 @@ Execute (Regular a function):
   call cursor(4,5)
   normal vaf<cr>
   AssertEqual 3, getpos("'<")[1]
-  AssertEqual 7, getpos("'>")[1]
+  AssertEqual 9, getpos("'>")[1]
 
 Execute (Multiline defn inner function):
   call cursor(15, 11)
@@ -25,7 +25,7 @@ Execute (Multiline defn a function):
   call cursor(15, 11)
   normal vaf<cr>
   AssertEqual 13, getpos("'<")[1]
-  AssertEqual 18, getpos("'>")[1]
+  AssertEqual 20, getpos("'>")[1]
 
 Execute (One-liner inner function):
   call cursor(21, 12)
@@ -37,7 +37,7 @@ Execute (One-liner a function):
   call cursor(21, 12)
   normal vaf<cr>
   AssertEqual 21, getpos("'<")[1]
-  AssertEqual 21, getpos("'>")[1]
+  AssertEqual 23, getpos("'>")[1]
 
 Execute (FIXME Multiline defn one-liner inner function):
   call cursor(24, 5)
@@ -49,7 +49,7 @@ Execute (Multiline defn one-liner a function):
   call cursor(24, 5)
   normal vaf<cr>
   AssertEqual 24, getpos("'<")[1]
-  AssertEqual 25, getpos("'>")[1]
+  AssertEqual 27, getpos("'>")[1]
 
 Execute (Outer nested function inner function):
   call cursor(29, 1)
@@ -61,7 +61,7 @@ Execute (Outer nested function a function):
   call cursor(29, 1)
   normal vaf<cr>
   AssertEqual 28, getpos("'<")[1]
-  AssertEqual 34, getpos("'>")[1]
+  AssertEqual 36, getpos("'>")[1]
 
 Execute (Inner nested function inner function):
   call cursor(32, 1)
@@ -85,7 +85,7 @@ Execute (Outer asynchronous function):
   call cursor(122, 1)
   normal vaf<cr>
   AssertEqual 121, getpos("'<")[1]
-  AssertEqual 123, getpos("'>")[1]
+  AssertEqual 125, getpos("'>")[1]
 
 Execute (Simple inner class):
   call cursor(41, 1)
@@ -97,7 +97,7 @@ Execute (Simple a class):
   call cursor(41, 1)
   normal vac<cr>
   AssertEqual 37, getpos("'<")[1]
-  AssertEqual 44, getpos("'>")[1]
+  AssertEqual 46, getpos("'>")[1]
 
 Execute (Multiple members inner class):
   call cursor(52, 1)
@@ -109,7 +109,7 @@ Execute (Multiple members a class):
   call cursor(52, 1)
   normal vac<cr>
   AssertEqual 47, getpos("'<")[1]
-  AssertEqual 53, getpos("'>")[1]
+  AssertEqual 55, getpos("'>")[1]
 
 Execute (Nested classes outer inner class):
   call cursor(56, 1)
@@ -121,7 +121,7 @@ Execute (Nested classes outer a class):
   call cursor(56, 1)
   normal vac<cr>
   AssertEqual 56, getpos("'<")[1]
-  AssertEqual 58, getpos("'>")[1]
+  AssertEqual 60, getpos("'>")[1]
 
 Execute (Nested classes inner inner class):
   call cursor(57, 1)
@@ -129,7 +129,7 @@ Execute (Nested classes inner inner class):
   AssertEqual 58, getpos("'<")[1]
   AssertEqual 58, getpos("'>")[1]
 
-Execute (Nested classes inner a class):
+Execute (FIXME Nested classes inner a class):
   call cursor(57, 1)
   normal vac<cr>
   AssertEqual 57, getpos("'<")[1]
@@ -141,11 +141,11 @@ Execute (Class nested in function inner class):
   AssertEqual 66, getpos("'<")[1]
   AssertEqual 70, getpos("'>")[1]
 
-Execute (Class nested in function a class):
+Execute (FIXME Class nested in function a class):
   call cursor(65, 1)
   normal vac<cr>
   AssertEqual 65, getpos("'<")[1]
-  AssertEqual 70, getpos("'>")[1]
+  AssertEqual 71, getpos("'>")[1]
 
 Execute (Function while in class nested in function inner class):
   call cursor(65, 1)
@@ -157,7 +157,7 @@ Execute (Function while in class nested in function a class):
   call cursor(65, 1)
   normal vaf<cr>
   AssertEqual 61, getpos("'<")[1]
-  AssertEqual 70, getpos("'>")[1]
+  AssertEqual 72, getpos("'>")[1]
 
 Execute (Old-style no ancestor class inner class):
   call cursor(86, 9)
@@ -169,7 +169,7 @@ Execute (Old-style no ancestor class a class):
   call cursor(86, 9)
   normal vac<cr>
   AssertEqual 86, getpos("'<")[1]
-  AssertEqual 91, getpos("'>")[1]
+  AssertEqual 93, getpos("'>")[1]
 
 Execute (Don't cross scope for defn):
   /^class no_defs
@@ -188,13 +188,14 @@ Execute (Decorator: function):
   /^def function_with_decorator(
   norm jvaf<cr>
   AssertEqual getline("."), "@decorator"
-  AssertEqual getline("'>"), "pass"
+  AssertEqual getpos("'>")[1], linenr + 3
 
 Execute (Decorators: function):
   /^def function_with_decorators(
+  let linenr = getpos(".")[1]
   norm jvaf<cr>
   AssertEqual getline("."), "@decorator"
-  AssertEqual getline("'>"), "pass"
+  AssertEqual getpos("'>")[1], linenr + 4
 
 Execute (Decorators: inner function):
   /^def function_with_decorators(
@@ -246,15 +247,17 @@ Execute (Decorators: inner function from decorators with multiple lines (6)):
 
 Execute (Decorators: function with decorators with multiple lines):
   /^def function_with_multiline_decorators(
+  let linenr = getpos(".")[1]
   norm kvaf<cr>
   AssertEqual getline("."), "@decorator"
-  AssertEqual getline("'>"), "pass"
+  AssertEqual getpos("'>")[1], linenr + 3
 
 Execute (Decorators: a function from decorator):
   /^def function_with_decorators(
+  let linenr = getpos(".")[1]
   norm kvaf<cr>
   AssertEqual getline("."), "@decorator"
-  AssertEqual getline("'>"), "pass"
+  AssertEqual getpos("'>")[1], linenr + 4
 
 Execute (Decorator: class):
   /^class ClassWithDecorator:
@@ -264,19 +267,21 @@ Execute (Decorator: class):
   /^class ClassWithDecorator:
   norm jvac<cr>
   AssertEqual getline("."), "@decorator"
-  AssertEqual getline("'>"), "pass"
+  AssertEqual getpos("'>")[1], linenr + 3
 
 Execute (Decorators: class):
   /^class ClassWithDecorators:
+  let linenr = getpos(".")[1]
   norm jvac<cr>
   AssertEqual getline("."), "@decorator"
-  AssertEqual getline("'>"), "pass"
+  AssertEqual getpos("'>")[1], linenr + 4
 
 Execute (Decorators: class from decorator):
   /^class ClassWithDecorators:
+  let linenr = getpos(".")[1]
   norm kvac<cr>
   AssertEqual getline("."), "@decorator"
-  AssertEqual getline("'>"), "pass"
+  AssertEqual getpos("'>")[1], linenr + 4
 
 Execute (Decorators: inner class from decorators with multiple lines):
   /^class ClassWithMultilineDecorators:

--- a/test/textobj-python.vader
+++ b/test/textobj-python.vader
@@ -179,6 +179,12 @@ Execute (Don't cross scope for defn):
   AssertEqual getpos(".")[1], linenr, "The line should not have changed."
   AssertThrows textobj#python#find_defn_line("def")
 
+Execute (Method with decorator):
+  /^    def method_with_decorator(
+  norm vaf<cr>
+  AssertEqual getpos("'<")[1], 163
+  AssertEqual getpos("'>")[1], 166
+
 Execute (At end of file, select prior whitespace):
   /^def at_end_of_file(
   norm vaf<cr>

--- a/test/textobj-python.vader
+++ b/test/textobj-python.vader
@@ -179,6 +179,12 @@ Execute (Don't cross scope for defn):
   AssertEqual getpos(".")[1], linenr, "The line should not have changed."
   AssertThrows textobj#python#find_defn_line("def")
 
+Execute (At end of file, select prior whitespace):
+  /^def at_end_of_file(
+  norm vaf<cr>
+  AssertEqual getpos("'<")[1], line("$") - 3
+  AssertEqual getpos("'>")[1], line("$")
+
 Execute (Decorator: function):
   /^def function_with_decorator(
   let linenr = getpos(".")[1]
@@ -321,6 +327,8 @@ Execute (Decorators: inner class from decorators with multiple lines (6)):
 
 Execute (Decorators: class with decorators with multiple lines):
   /^class ClassWithMultilineDecorators:
+  let linenr = getpos(".")[1]
   norm kvac<cr>
   AssertEqual getline("."), "@decorator"
-  AssertEqual getline("'>"), "pass"
+  AssertEqual getpos("'>")[1], 158
+  AssertEqual getpos("'>")[1], linenr + 4


### PR DESCRIPTION
This implements whitespace handling that closely modeled after `ap`, in which now `af`/`ac` will also select any blank lines after the selected function/class.

One case where it deliberately deviate from the behaviour of `ap` is at the end of a block where the next block is a top level block, for example:

```
class Foo:
    def bar(self):
        pass

    def baz(self):
        pass


class Mee:
    pass
```

deleting Foo.baz here with `dap` would leave one space between Foo and Mee class, which will not be PEP8 compliant. Instead, `daf` is smarter and leaves two spaces here.

Like `ap`, the current implementation never selects blank lines prior to the text object unless you're at the end of the file, in which case it'll delete all prior blank lines as so not to leave you with blank lines at the end of file. This means that deleting a block that had three preceding blank lines will leave three preceding blank lines, which is not PEP8 compliant. 

This current behaviour should be very familiar for most vim users that are used to the default whitespace handling for `ap`/`aw`. Also, as far as I can tell if your file's spacing was PEP8 compliant, the new behaviour always leave the file PEP8 compliant. If your file wasn't PEP8 compliant to begin with, then the current behaviour won't force PEP8 spacing on you, but instead will mostly preserve the deviation. I think this is a good default behaviour, because if you deviate from PEP8, you probably have a good reason for doing so (and if what you want is for your editor to always fix up everything automatically, then you probably should be using black).