### PR TITLE
Support multiline typings

### DIFF
--- a/test/test-typing.py
+++ b/test/test-typing.py
@@ -1,0 +1,95 @@
+from typing import Generic, List, Tuple, TypeVar
+
+T = TypeVar('T')
+S = TypeVar('S')
+
+
+class ClassWithTyping(Generic[T]):
+    pass
+
+
+class ClassWithTypings(Generic[T, S]):
+    # ClassWithTyping
+    pass
+
+
+def function_with_typing(foo: str) -> None:
+    pass
+
+
+def function_with_typings(foo: str, bar: int) -> None:
+    # function_with_typings
+    pass
+
+
+def oneliner_with_typing(foo: str) -> None: pass
+
+
+def function_with_multiline_typings(
+    foo: str,
+    bar: List[int],
+    baz: T, qux: S,
+) -> Tuple[
+    str, # comment
+    Tuple[
+        int,
+        int,
+    ],
+    # comment
+    T, S,
+]:
+    # function_with_multiline_typings
+    pass
+
+
+def oneliner_with_multiline_typings(
+    foo: str,
+    bar: List[int],
+    baz: T, qux: S,
+) -> Tuple[
+    str, # comment
+    Tuple[
+        int,
+        int,
+    ],
+    # comment
+    T, S,
+]: pass
+
+
+class ClassWithMultilineTypings(Generic[
+        T, # comment
+        # comment
+        S,
+]):
+    # ClassWithMultilineTypings
+    pass
+
+
+class RegularClass():
+    def foo(self):
+        pass
+
+    def method_with_typing(self, bar: str) -> None:
+        pass
+
+    def method_with_multiline_typings(
+        self,
+        foo: str,
+        bar: List[int],
+        baz: T, qux: S,
+    ) -> Tuple[
+        str, # comment
+        Tuple[
+            int,
+            int,
+        ],
+        # comment
+        T, S,
+    ]:
+        # method_with_multiline_typings
+        pass
+
+
+def at_end_of_file():
+    pass

--- a/test/textobj-python-typing.vader
+++ b/test/textobj-python-typing.vader
@@ -1,0 +1,224 @@
+Before (Read in test-typing.py):
+  execute "read " . globpath(fnamemodify(g:vader_file, ":h"), "test-typing.py")
+  setf python
+  normal 1Gdd
+
+Execute (Typing: function):
+  /^def function_with_typing(
+  let linenr = getpos(".")[1]
+  norm vaf<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 3
+
+Execute (Typing: inner function):
+  /^def function_with_typing(
+  let linenr = getpos(".")[1]
+  norm vif<cr>
+  AssertEqual getpos("'<")[1], linenr + 1
+  AssertEqual getpos("'>")[1], linenr + 1
+
+Execute (Typings: function):
+  /^def function_with_typings(
+  let linenr = getpos(".")[1]
+  norm vaf<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 4
+
+Execute (Typings: function from typing):
+  /^def function_with_typings(foo:\zs
+  let linenr = getpos(".")[1]
+  norm vaf<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 4
+
+Execute (Typings: inner function):
+  /^def function_with_typings(
+  norm vif<cr>
+  AssertEqual getline("."), "# function_with_typings"
+  AssertEqual getline("'>"), "pass"
+
+Execute (Typings: inner function from typing):
+  /^def function_with_typings(foo:\zs
+  norm vif<cr>
+  AssertEqual getline("."), "# function_with_typings"
+  AssertEqual getline("'>"), "pass"
+
+Execute (Typing: One-liner inner function v-mode):
+  /^def oneliner_with_typing(
+  let linenr = getpos(".")[1]
+  normal vif<cr>
+  AssertEqual [linenr, 45], getpos("'<")[1:2]
+  AssertEqual [linenr, 49], getpos("'>")[1:2]
+
+Execute (Typings: inner function from typings with multiple lines):
+  /^def function_with_multiline_typings(
+  norm jvif<cr>
+  AssertEqual getline("."), "# function_with_multiline_typings"
+  AssertEqual getline("'>"), "pass"
+
+Execute (Typings: inner function from typings with multiple lines (2)):
+  /^def function_with_multiline_typings(
+  norm 4jvif<cr>
+  AssertEqual getline("."), "# function_with_multiline_typings"
+  AssertEqual getline("'>"), "pass"
+
+Execute (Typings: inner function from typings with multiple lines (3)):
+  /^def function_with_multiline_typings(
+  norm 5jvif<cr>
+  AssertEqual getline("."), "# function_with_multiline_typings"
+  AssertEqual getline("'>"), "pass"
+
+Execute (Typings: inner function from typings with multiple lines (4)):
+  /^def function_with_multiline_typings(
+  norm 6jvif<cr>
+  AssertEqual getline("."), "# function_with_multiline_typings"
+  AssertEqual getline("'>"), "pass"
+
+Execute (Typings: inner function from typings with multiple lines (5)):
+  /^def function_with_multiline_typings(
+  norm 7jvif<cr>
+  AssertEqual getline("."), "# function_with_multiline_typings"
+  AssertEqual getline("'>"), "pass"
+
+Execute (Typings: inner function from typings with multiple lines (6)):
+  /^def function_with_multiline_typings(
+  norm 10jvif<cr>
+  AssertEqual getline("."), "# function_with_multiline_typings"
+  AssertEqual getline("'>"), "pass"
+
+Execute (Typings: function with typings with multiple lines):
+  /^def function_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm jvaf<cr>
+  AssertEqual getline("."), "def function_with_multiline_typings("
+  AssertEqual getpos("'>")[1], linenr + 16
+
+Execute (Typings: One-liner inner function from typings with multiple lines):
+  /^def oneliner_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm jvif<cr>
+  AssertEqual [linenr + 12, 4], getpos("'<")[1:2]
+  AssertEqual [linenr + 12, 8], getpos("'>")[1:2]
+
+Execute (Typings: One-liner inner function from typings with multiple lines (2)):
+  /^def oneliner_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm 5jvif<cr>
+  AssertEqual [linenr + 12, 4], getpos("'<")[1:2]
+  AssertEqual [linenr + 12, 8], getpos("'>")[1:2]
+
+Execute (Typing: class):
+  /^class ClassWithTyping(
+  let linenr = getpos(".")[1]
+  norm vac<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 3
+
+Execute (Typings: class):
+  /^class ClassWithTypings(
+  let linenr = getpos(".")[1]
+  norm vac<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 4
+
+Execute (Typings: class from typing):
+  /^class ClassWithTypings(Generic\[\zs
+  let linenr = getpos(".")[1]
+  norm vac<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 4
+
+Execute (Typings: inner class from typings with multiple lines):
+  /^class ClassWithMultilineTypings(
+  norm vic<cr>
+  AssertEqual getline("."), "# ClassWithMultilineTypings"
+  AssertEqual getline("'>"), "pass"
+
+Execute (Typings: inner class from typings with multiple lines (2)):
+  /^class ClassWithMultilineTypings(
+  norm jvic<cr>
+  AssertEqual getline("."), "# ClassWithMultilineTypings"
+  AssertEqual getline("'>"), "pass"
+
+Execute (Typings: inner class from typings with multiple lines (3)):
+  /^class ClassWithMultilineTypings(
+  norm 3jvic<cr>
+  AssertEqual getline("."), "# ClassWithMultilineTypings"
+  AssertEqual getline("'>"), "pass"
+
+Execute (Typings: class with typings with multiple lines):
+  /^class ClassWithMultilineTypings(
+  let linenr = getpos(".")[1]
+  norm jvac<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 8
+
+Execute (Typing: method with typing):
+  /^    def method_with_typing(
+  let linenr = getpos(".")[1]
+  norm vaf<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 2
+
+Execute (Typings: method with typings with multiple lines):
+  /^    def method_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm vaf<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 16
+
+Execute (Typings: method from typings with multiple lines):
+  /^    def method_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm jvaf<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 16
+
+Execute (Typings: method from typings with multiple lines (2)):
+  /^    def method_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm 5jvaf<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 16
+
+Execute (Typings: method from typings with multiple lines (3)):
+  /^    def method_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm 6jvaf<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 16
+
+Execute (Typings: method from typings with multiple lines (4)):
+  /^    def method_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm 8jvaf<cr>
+  AssertEqual getpos("'<")[1], linenr
+  AssertEqual getpos("'>")[1], linenr + 16
+
+Execute (Typings: inner method from typings with multiple lines):
+  /^    def method_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm jvif<cr>
+  AssertEqual getline("."), "    # method_with_multiline_typings"
+  AssertEqual getline("'>"), "    pass"
+
+Execute (Typings: inner method from typings with multiple lines (2)):
+  /^    def method_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm 5jvif<cr>
+  AssertEqual getline("."), "    # method_with_multiline_typings"
+  AssertEqual getline("'>"), "    pass"
+
+Execute (Typings: inner method from typings with multiple lines (3)):
+  /^    def method_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm 6jvif<cr>
+  AssertEqual getline("."), "    # method_with_multiline_typings"
+  AssertEqual getline("'>"), "    pass"
+
+Execute (Typings: inner method from typings with multiple lines (4)):
+  /^    def method_with_multiline_typings(
+  let linenr = getpos(".")[1]
+  norm 8jvif<cr>
+  AssertEqual getline("."), "    # method_with_multiline_typings"
+  AssertEqual getline("'>"), "    pass"

--- a/test/textobj-python.vader
+++ b/test/textobj-python.vader
@@ -27,11 +27,11 @@ Execute (Multiline defn a function):
   AssertEqual 13, getpos("'<")[1]
   AssertEqual 20, getpos("'>")[1]
 
-Execute (One-liner inner function):
+Execute (One-liner inner function v-mode):
   call cursor(21, 12)
   normal vif<cr>
-  AssertEqual 21, getpos("'<")[1]
-  AssertEqual 21, getpos("'>")[1]
+  AssertEqual [21, 17], getpos("'<")[1:2]
+  AssertEqual [21, 21], getpos("'>")[1:2]
 
 Execute (One-liner a function):
   call cursor(21, 12)
@@ -39,10 +39,10 @@ Execute (One-liner a function):
   AssertEqual 21, getpos("'<")[1]
   AssertEqual 23, getpos("'>")[1]
 
-Execute (FIXME Multiline defn one-liner inner function):
+Execute (Multiline defn one-liner inner function v-mode):
   call cursor(24, 5)
   normal vif<cr>
-  AssertEqual 24, getpos("'<")[1]
+  AssertEqual 25, getpos("'<")[1]
   AssertEqual 25, getpos("'>")[1]
 
 Execute (Multiline defn one-liner a function):
@@ -177,7 +177,7 @@ Execute (Don't cross scope for defn):
   let linenr = getpos(".")[1]
   norm vaf<cr>
   AssertEqual getpos(".")[1], linenr, "The line should not have changed."
-  AssertThrows textobj#python#find_defn_line("def")
+  AssertEqual 0, textobj#python#find_defn_pos("def")
 
 Execute (Method with decorator):
   /^    def method_with_decorator(
@@ -193,14 +193,15 @@ Execute (At end of file, select prior whitespace):
 
 Execute (Decorator: function):
   /^def function_with_decorator(
-  let linenr = getpos(".")[1]
-"   debug call textobj#python#find_prev_decorators(linenr)
-  AssertEqual linenr-1, textobj#python#find_prev_decorators(linenr)
+  let pos = getpos(".")
+  let expected = [pos[0], pos[1] - 1] + pos[2:]
+"   debug call textobj#python#find_prev_decorators_pos(pos)
+  AssertEqual expected, textobj#python#find_prev_decorators_pos(pos)
   " Move cursor back
   /^def function_with_decorator(
   norm jvaf<cr>
   AssertEqual getline("."), "@decorator"
-  AssertEqual getpos("'>")[1], linenr + 3
+  AssertEqual getpos("'>")[1], pos[1] + 3
 
 Execute (Decorators: function):
   /^def function_with_decorators(
@@ -273,13 +274,14 @@ Execute (Decorators: a function from decorator):
 
 Execute (Decorator: class):
   /^class ClassWithDecorator:
-  let linenr = getpos(".")[1]
-  AssertEqual linenr-1, textobj#python#find_prev_decorators(linenr)
+  let pos = getpos(".")
+  let expected = [pos[0], pos[1] - 1] + pos[2:]
+  AssertEqual expected, textobj#python#find_prev_decorators_pos(pos)
   " Move cursor back
   /^class ClassWithDecorator:
   norm jvac<cr>
   AssertEqual getline("."), "@decorator"
-  AssertEqual getpos("'>")[1], linenr + 3
+  AssertEqual getpos("'>")[1], pos[1] + 3
 
 Execute (Decorators: class):
   /^class ClassWithDecorators:


### PR DESCRIPTION
Sorry there are many changes.
I would appreciate it if you could merge it.

* Support multiline typings.
* FIx one-liner. Select by `v` mode.
* Skip comments that the indent level shallower.
* Do not use `:normal`, It's broken when folding. (ex. infinite loop etc...)
* Do not use `:throw`.